### PR TITLE
[CRIP-4] - Integrar Swagger al proyecto

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-security")
+	//implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -28,7 +28,8 @@ dependencies {
 	runtimeOnly("com.h2database:h2")
 	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.springframework.security:spring-security-test")
+	//testImplementation("org.springframework.security:spring-security-test")
+	implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
+springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
Este PR resuelve [CRIP-4](https://criptop2p.atlassian.net/browse/CRIP-4)

Integra open api v3 y swagger al proyecto. Las dependencias de spring security fueron comentadas para que no pida loguearse al acceder a las rutas. Por el momento no son necesarias, mas adelante las configuraremos bien.

Se puede acceder a la documentación desde:

- http://localhost:8080/api-docs (JSON plano)
- http://localhost:8080/swagger-ui.html (Swagger UI)