### PR TITLE
Crip 26 swagger documentation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,0 +1,32 @@
+---------------------------------------------------------------------
+TAG ENTREGA1
+---------------------------------------------------------------------
+NEW FEATURES:
+    Core
+        Creación de repositorios GitHub
+        Configuración en Travis/GitHubActions
+        Build corriendo y SUCCESS
+        SonarCloud (Registrar el proyecto Backend)
+        Deploy automático utlizando HEROKU o cualquiera similar para deploy Automático
+        Clean Code según la materia
+        Configuracion de swagge (v3)
+        Estado de build en "Verde"
+        Utilizar H2 para persistir datos
+
+    Modelo
+        Implementar modelo completo
+        Testing automático unitario según las pautas de la materia
+
+    Funcionalidad
+        Proveer servicio de registracion de usuario
+        Listar cotizacion de criptoactivos
+        Permitir que un usuario exprese su intención de compra/venta
+        Segurizar el acceso a la API (JWT)
+        Mostrar las cotizaciones de las últimas 24hs para un cripto activo dado
+        Listado de cotizaciones
+
+NOTES:
+    Listado de cotizaciones: Testear performance
+
+KNOWN ISSUES:
+    -

--- a/src/main/kotlin/ar/edu/unq/criptop2p/controller/CryptoController.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/controller/CryptoController.kt
@@ -2,6 +2,7 @@ package ar.edu.unq.criptop2p.controller
 
 import ar.edu.unq.criptop2p.model.CryptoCurrency
 import ar.edu.unq.criptop2p.service.CryptoService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,14 +16,16 @@ class CryptoController (
     @Autowired
     private val cryptoService: CryptoService){
 
-    @GetMapping("/prices")
-    fun prices(): ResponseEntity<List<CryptoCurrency>> {
-        return ResponseEntity.ok().body(this.cryptoService.getCryptoPrices())
-    }
-
+    @Operation(summary="API to list the 24hs prices of a cryptocurrency", description="This endpoint list the last 24hs prices of the cryptocurrency send by parameter.")
     @GetMapping("/price/{symbol}")
     fun last24HsPrices(@PathVariable symbol:String): ResponseEntity<List<CryptoCurrency>> {
         return ResponseEntity.ok().body(this.cryptoService.getLast24HsPrices(symbol))
+    }
+
+    @Operation(summary="API to list current cryptocurrency prices", description="This endpoint list the current price of all the cryptocurrencies supported by the platform.")
+    @GetMapping("/prices")
+    fun prices(): ResponseEntity<List<CryptoCurrency>> {
+        return ResponseEntity.ok().body(this.cryptoService.getCryptoPrices())
     }
 
 }

--- a/src/main/kotlin/ar/edu/unq/criptop2p/controller/RequestController.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/controller/RequestController.kt
@@ -4,6 +4,7 @@ package ar.edu.unq.criptop2p.controller
 import ar.edu.unq.criptop2p.controller.dto.RequestDTO
 import ar.edu.unq.criptop2p.service.RequestService
 import ar.edu.unq.criptop2p.service.UserService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 
@@ -16,6 +17,7 @@ class RequestController(
     private val userService: UserService
 ) {
 
+    @Operation(summary="API to post a Request", description="This endpoint allow a registered user to post a Request. Parameters BUY | SELL. (secret_token needed)")
     @PostMapping("/{requestType}")
     fun save(
         @PathVariable requestType: String,

--- a/src/main/kotlin/ar/edu/unq/criptop2p/controller/UserController.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/controller/UserController.kt
@@ -4,6 +4,7 @@ import ar.edu.unq.criptop2p.controller.dto.ListableUserDTO
 import ar.edu.unq.criptop2p.controller.dto.LoginDTO
 import ar.edu.unq.criptop2p.controller.dto.UserDTO
 import ar.edu.unq.criptop2p.service.UserService
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -16,6 +17,7 @@ class UserController(
     private val userService: UserService
 ) {
 
+    @Operation(summary="API for user registration", description="This endpoint registers a new user on the platform.")
     @PostMapping("register")
     fun register(
         @Valid
@@ -25,6 +27,7 @@ class UserController(
         userService.save(userDto)
     }
 
+    @Operation(summary="API for user login", description="This endpoint authenticate a user by email and password and returns a secret token.")
     @PostMapping("login")
     fun login(
         @Valid
@@ -34,6 +37,7 @@ class UserController(
         return userService.login(loginDTO)
     }
 
+    @Operation(summary="API to list users", description="This endpoint list all the registered users on the platform.")
     @GetMapping("/list")
     fun getUserList(): ResponseEntity<List<ListableUserDTO>> {
         return ResponseEntity.ok().body(userService.getUserList())

--- a/src/main/kotlin/ar/edu/unq/criptop2p/controller/dto/LoginDTO.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/controller/dto/LoginDTO.kt
@@ -1,10 +1,12 @@
 package ar.edu.unq.criptop2p.controller.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Pattern
 
 data class LoginDTO(
+    @field:Schema(name="email", description="Must have a valid email format")
     @field:[Email(message = "email should be a valid address") NotEmpty(message = "email should not be empty")]
     val email: String,
     @field:Pattern(

--- a/src/main/kotlin/ar/edu/unq/criptop2p/controller/dto/UserDTO.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/controller/dto/UserDTO.kt
@@ -2,6 +2,7 @@ package ar.edu.unq.criptop2p.controller.dto
 
 import ar.edu.unq.criptop2p.model.Address
 import ar.edu.unq.criptop2p.model.User
+import io.swagger.v3.oas.annotations.media.Schema
 import javax.validation.Valid
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotEmpty
@@ -13,6 +14,7 @@ class UserDTO(
     val firstName: String,
     @field:Size(min = 3, max = 30, message = "lastName length should be min 3 max 30")
     val lastName: String,
+    @field:Schema(name="email", description="Must have a valid email format")
     @field:[Email(message = "email should be a valid address") NotEmpty(message = "email should not be empty")]
     val email: String,
     @field:Pattern(

--- a/src/main/kotlin/ar/edu/unq/criptop2p/model/CryptoCurrency.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/model/CryptoCurrency.kt
@@ -1,5 +1,6 @@
 package ar.edu.unq.criptop2p.model
 
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 import javax.persistence.*
 
@@ -7,6 +8,7 @@ import javax.persistence.*
 class CryptoCurrency(
     @Column
     private val price: Double,
+    @field:Schema(name="symbol", description="Symbol must be supported by the platform")
     @Column
     private val symbol: String,
     @Column


### PR DESCRIPTION
En este PR se documentaron en swagger las API creadas en el primer sprint. A partir de ahora, todas APIs que se generen deberían documentarse siguiendo este criterio.

Les agregué un nombre y una descripción a los endpoints:
![imagen](https://user-images.githubusercontent.com/70177158/193426619-8120b9f9-9a59-4c58-b8c8-4e00b3c40879.png)

En los schemas agregué una descripción solo en los datos que tenían alguna regla no muy clara (symbol, email):
![imagen](https://user-images.githubusercontent.com/70177158/193426673-b3ad30a3-f329-4bb7-8f35-2098d45e53cb.png)

Si te parece que hay que documentar algo más me avisas y lo voy agregando.
