### PR TITLE
Refactor transactions amount, transactions tests. Fix config.kt data …

### DIFF
--- a/src/main/kotlin/ar/edu/unq/criptop2p/model/Request.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/model/Request.kt
@@ -60,7 +60,6 @@ class Request(
         this.status.updateStatus(this, nextStatus, requester, currentPrice)
     }
 
-    fun amountOperated(user: User): Double = this.getType().amountOperated(this, user)
-    fun priceOperated(user: User): Pair<Double, Double> = this.getType().priceOperated(this, user)
+    fun priceOperated(): Pair<Double, Double> = this.getType().priceOperated(this)
 
 }

--- a/src/main/kotlin/ar/edu/unq/criptop2p/model/RequestEnum.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/model/RequestEnum.kt
@@ -131,21 +131,14 @@ enum class RequestType {
         override fun exceedsPriceGap(currentPrice: Double, request: Request) : Boolean =
             currentPrice < (request.getCryptoCurrency().getPrice() * 0.95)
 
-        override fun getAmount(request: Request): Double = - request.getAmount()
-
     };
 
     abstract fun exceedsPriceGap(currentPrice: Double, request: Request) : Boolean
 
-    private fun getFor(user:User, request:Request, value:Double) =
-            if (user.getId() == request.getOwner().getId()) value else - value
+    private fun usdOperated(request: Request) = request.getAmount() * request.getCryptoCurrency().getPrice()
 
-    open fun getAmount(request: Request): Double = request.getAmount()
-    fun amountOperated(request: Request, user: User) = getFor(user, request, getAmount(request))
-
-    private fun usdOperated(request: Request) = getAmount(request) * request.getCryptoCurrency().getPrice()
-    fun priceOperated(request: Request, user: User): Pair<Double, Double> {
-        val usdOperated = getFor(user, request, usdOperated(request))
+    fun priceOperated(request: Request): Pair<Double, Double> {
+        val usdOperated = usdOperated(request)
         return Pair(usdOperated, usdOperated * request.getPriceArgAtCompletation())
     }
 

--- a/src/main/kotlin/ar/edu/unq/criptop2p/persistance/mockedData/Config.kt
+++ b/src/main/kotlin/ar/edu/unq/criptop2p/persistance/mockedData/Config.kt
@@ -3,6 +3,7 @@ package ar.edu.unq.criptop2p.persistance.mockedData
 import ar.edu.unq.criptop2p.model.*
 import ar.edu.unq.criptop2p.persistance.RequestRepository
 import ar.edu.unq.criptop2p.persistance.UserRepository
+import ar.edu.unq.criptop2p.service.CryptoService
 import ar.edu.unq.criptop2p.service.RequestService
 import org.springframework.boot.CommandLineRunner
 import org.springframework.context.annotation.Bean
@@ -15,7 +16,7 @@ import java.util.*
 class Config {
 
     @Bean
-    fun run(userRepository: UserRepository, requestRepository: RequestRepository, requestService:RequestService): CommandLineRunner {
+    fun run(userRepository: UserRepository, requestRepository: RequestRepository, requestService:RequestService, cryptoService: CryptoService): CommandLineRunner {
         return CommandLineRunner { _ ->
 
             // Setting up users
@@ -99,9 +100,12 @@ class Config {
                 richardRoe,
                 RequestType.BUY
             )
+
+            val currentPriceCAKEUSDT = cryptoService.getPrice("CAKEUSDT")
+
             val request4 = Request(
                 CryptoCurrency(
-                    4.465,
+                    currentPriceCAKEUSDT,
                     "CAKEUSDT",
                     currentDate
                 ),
@@ -112,9 +116,9 @@ class Config {
 
             val request5 = Request(
                     CryptoCurrency(
-                            4.465,
-                            "CAKEUSDT",
-                            currentDate
+                        currentPriceCAKEUSDT,
+                        "CAKEUSDT",
+                        currentDate
                     ),
                     60.0,
                     richardRoe,
@@ -123,28 +127,57 @@ class Config {
 
             val request6 = Request(
                     CryptoCurrency(
-                            4.465,
-                            "CAKEUSDT",
-                            currentDate
+                        currentPriceCAKEUSDT,
+                        "CAKEUSDT",
+                        currentDate
                     ),
                     25.0,
                     richardRoe,
                     RequestType.SELL           )
 
-            requestRepository.saveAll(listOf(request1, request2, request3, request4, request5, request6))
+            val currentPriceALICEUSDT = cryptoService.getPrice("ALICEUSDT")
+
+            val request7 = Request(
+                    CryptoCurrency(
+                            currentPriceALICEUSDT,
+                            "ALICEUSDT",
+                            currentDate
+                    ),
+                    72.0,
+                    richardRoe,
+                    RequestType.BUY
+            )
+            val request8 = Request(
+                    CryptoCurrency(
+                            currentPriceALICEUSDT,
+                            "ALICEUSDT",
+                            currentDate
+                    ),
+                    38.0,
+                    richardRoe,
+                    RequestType.SELL
+            )
+
+            requestRepository.saveAll(listOf(request1, request2, request3, request4, request5, request6, request7, request8))
 
             requestService.updateStatus(4, RequestStatus.ACCEPTED, janePoe)
             requestService.updateStatus(5, RequestStatus.ACCEPTED, janePoe)
             requestService.updateStatus(6, RequestStatus.ACCEPTED, janePoe)
+            requestService.updateStatus(7, RequestStatus.ACCEPTED, janePoe)
+            requestService.updateStatus(8, RequestStatus.ACCEPTED, janePoe)
 
 
             requestService.updateStatus(4, RequestStatus.WAITING_CONFIRMATION, janePoe)
             requestService.updateStatus(5, RequestStatus.WAITING_CONFIRMATION, janePoe)
             requestService.updateStatus(6, RequestStatus.WAITING_CONFIRMATION, janePoe)
+            requestService.updateStatus(7, RequestStatus.WAITING_CONFIRMATION, janePoe)
+            requestService.updateStatus(8, RequestStatus.WAITING_CONFIRMATION, janePoe)
 
             requestService.updateStatus(4, RequestStatus.CONFIRMED, richardRoe)
             requestService.updateStatus(5, RequestStatus.CONFIRMED, richardRoe)
             requestService.updateStatus(6, RequestStatus.CONFIRMED, richardRoe)
+            requestService.updateStatus(7, RequestStatus.CONFIRMED, richardRoe)
+            requestService.updateStatus(8, RequestStatus.CONFIRMED, richardRoe)
 
         }
     }

--- a/src/test/kotlin/ar/edu/unq/criptop2p/model/TransactionTest.kt
+++ b/src/test/kotlin/ar/edu/unq/criptop2p/model/TransactionTest.kt
@@ -18,10 +18,8 @@ internal class TransactionTest : AbstractTest() {
                                                              owner = aUserOwner,
                                                              counterpart = aUserCounterpart)
 
-        assertEquals(50.0 , confirmedRequestBuy.amountOperated(aUserOwner))
-        assertEquals(-50.0, confirmedRequestBuy.amountOperated(aUserCounterpart))
-        assertEquals(-10.0, confirmedRequestSell.amountOperated(aUserOwner))
-        assertEquals(10.0, confirmedRequestSell.amountOperated(aUserCounterpart))
+        assertEquals(50.0 , confirmedRequestBuy.getAmount())
+        assertEquals(10.0, confirmedRequestSell.getAmount())
 
     }
 
@@ -43,10 +41,8 @@ internal class TransactionTest : AbstractTest() {
                                                              priceArgAtCompletation = 200.0)
 
 
-        assertEquals(Pair(500.0, 100000.0), confirmedRequestBuy.priceOperated(aUserOwner))
-        assertEquals(Pair(-500.0, -100000.0), confirmedRequestBuy.priceOperated(aUserCounterpart))
-        assertEquals(Pair(-100.0, -20000.0), confirmedRequestSell.priceOperated(aUserOwner))
-        assertEquals(Pair(100.0, 20000.0), confirmedRequestSell.priceOperated(aUserCounterpart))
+        assertEquals(Pair(500.0, 100000.0), confirmedRequestBuy.priceOperated())
+        assertEquals(Pair(100.0, 20000.0), confirmedRequestSell.priceOperated())
     }
 
 }


### PR DESCRIPTION
Buenas, te paso el resumen:

- Realicé los refactors necesarios para corregir lo marcado en CRIP-42 (Sumar valores de compra y venta en volumen operado)
- A raíz de esos cambios, tuve que modificar los test de transacciones.
- Además, algunos test fallaban por la diferencia de precios al momento de ejecutarlos, así que cambie el config.kt para que tome los datos actuales de las crypto al crear los request.

Grax! 